### PR TITLE
Rotate the screen so that the camera is aiming at the center of the movie

### DIFF
--- a/src/videojs.vr.js
+++ b/src/videojs.vr.js
@@ -65,6 +65,9 @@
             movieScreen = new THREE.Mesh( movieGeometry, movieMaterial );
             movieScreen.position.set(position.x, position.y, position.z);
             movieScreen.scale.x = -1;
+            if ((projection === "Sphere") || (projection === "Cylinder")) {
+                movieScreen.quaternion.setFromAxisAngle({x: 0, y: 1, z: 0}, -Math.PI / 2);
+            }
             scene.add(movieScreen);
         }
 


### PR DESCRIPTION
This PR updates the projection setup method by adding a rotation of the screen mesh, for sphere and cylinder projections, making the camera aim at the "center" of the (unprojected) movie.
This can be useful when the titling expects the camera to be setup in this direction.