### PR TITLE
Expose ThreeJS perspective camera in player.vr object

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,19 @@ Oculus Rift and HTC Vive playback requires Firefox Nightly with the WebVR addon,
 GearVR playback requires the latest Samsung Internet for Gear VR with WebVR support enabled. Go [here](https://mail.mozilla.org/pipermail/web-vr-discuss/2016-April/001054.html) for more info.
 
 ## Accessing the Camera Position
-The Three.js camera is exposed as a property `cameraVector` on the `vr` plugin namespace. For example, assuming the parent element for Video.js is `#video-container` the following code would return the current `cameraVector` value:
+The Three.js perspective camera and rotation values are exposed as the properties `camera` and `cameraVector` on the `vr` plugin namespace.
+
+For example, assuming the parent element for Video.js is `#video-container` the following code would return the current `camera` object:
+
+    document.getElementById('video-container').player.vr.camera
+
+and:
 
     document.getElementById('video-container').player.vr.cameraVector
+ 
+ would return the current `cameraVector` value:
 
-See `example-camera.html` for a working demo that logs camera position to the console every second.
+See `example-camera.html` for a working demo that logs camera object and rotation to the console every second.
 
 ## Credits ##
 

--- a/example-camera.html
+++ b/example-camera.html
@@ -41,8 +41,10 @@ if ('SamsungChangeSky' in window) {
 </script>
 
 <script>
+    var player;
+
     (function(){
-        var player = videojs( '#video-container', {
+        player = videojs( '#video-container', {
             techOrder: ['html5']
         });
         player.vr({projection: "360"});
@@ -50,7 +52,9 @@ if ('SamsungChangeSky' in window) {
 
     setInterval( function() {
       console.log("cameraVector");
-      console.log(document.getElementById('video-container').player.vr.cameraVector);
+      console.log(player.vr.cameraVector);
+      console.log("Three JS perspective camera");
+      console.log(player.vr.camera);
     }, 1000);
 </script>
 </body>

--- a/src/js/videojs.vr.js
+++ b/src/js/videojs.vr.js
@@ -435,6 +435,7 @@
                return radians * 180 / Math.PI;
             }
 
+            // Expose the Three.js perspective camera and rotation values on the player under the 'vr' namespace:
             player.vr = {
               camera: camera,
               cameraVector: cameraVector

--- a/src/js/videojs.vr.js
+++ b/src/js/videojs.vr.js
@@ -436,6 +436,7 @@
             }
 
             player.vr = {
+              camera: camera,
               cameraVector: cameraVector
             };
         }


### PR DESCRIPTION
HapYak needs access to the actual ThreeJS Perspective Camera object in order to set camera.fov, camera.rotation.order, and to run camera.updateProjectMatrix(). We would like to include it here alongside the cameraVector for ease of access.