### PR TITLE
Removal of HLS and Dash from No Video Js Build

### DIFF
--- a/src/js/player-no-videojs.js
+++ b/src/js/player-no-videojs.js
@@ -1,6 +1,3 @@
-require('dashjs');
-require('videojs-contrib-dash');
-require('videojs-contrib-hls');
 global.THREE = require('three');
 require('three/examples/js/controls/VRControls.js');
 require('three/examples/js/effects/VREffect.js');


### PR DESCRIPTION
Removing HLS and Dash JS references from the No Video JS Build to reduce the footprint