### PR TITLE
Fix updated folder structure of requirement

### DIFF
--- a/src/css/player.css
+++ b/src/css/player.css
@@ -1,2 +1,2 @@
 @import "../../node_modules/video.js/dist/video-js.css";
-@import "../../node_modules/videojs-errors/dist/videojs-errors.css";
+@import "../../node_modules/videojs-errors/dist/browser/videojs-errors.css";


### PR DESCRIPTION
The required video.js plugin "videojs-errors" has changed its folder structure.
To be able to build videojs-vr this requirement has to be fixed.