### PR TITLE
Fix dimensions and ratio calculations for non full window player

### DIFF
--- a/src/js/videojs.vr.js
+++ b/src/js/videojs.vr.js
@@ -171,7 +171,7 @@
                 camera,
                 renderedCanvas;
 
-            camera = new THREE.PerspectiveCamera( settings.fov, window.innerWidth / window.innerHeight, 1, 1000 );
+            camera = new THREE.PerspectiveCamera( settings.fov, videoEl.offsetWidth / videoEl.offsetHeight, 1, 1000 );
 
             cameraVector = new THREE.Vector3(); // Store vector representing the direction in which the camera is looking, in world space.
 
@@ -260,9 +260,9 @@
                 antialias: true
             });
 
-            renderer.setSize(window.innerWidth, window.innerHeight);
+            renderer.setSize(videoEl.offsetWidth, videoEl.offsetHeight);
             effect = new THREE.VREffect(renderer);
-            effect.setSize(window.innerWidth, window.innerHeight);
+            effect.setSize(videoEl.offsetWidth, videoEl.offsetHeight);
 
             var vrDisplay = null;
             var frameData = null;
@@ -282,8 +282,8 @@
             // Handle window resizes
             function onWindowResize() {
                 //if (window.orientation == undefined) {
-                    effect.setSize(window.innerWidth, window.innerHeight);
-                    camera.aspect = window.innerWidth / window.innerHeight;
+                    effect.setSize(renderedCanvas.offsetWidth, renderedCanvas.offsetHeight);
+                    camera.aspect = renderedCanvas.offsetWidth / renderedCanvas.offsetHeight;
                     camera.updateProjectionMatrix();
                 //}
             }


### PR DESCRIPTION
The setup and resizing code assumes that the player is using the full browser window by using window.inner dimensions.
This PR uses the video element's or the canvas' size instead, to make dimensions and ratio calculations correct when the player is not using the full window.