### PR TITLE
part revert to allow webvr to still work when there is no webxr plug-in

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -760,7 +760,7 @@ void main() {
           this.renderer.xr.setSession(this.currentSession);
         };
       });
-    } else {
+
       this.initVRPolyfill(displays);
     }
   }


### PR DESCRIPTION
## Description
part revert to allow webvr to still work when there is no webxr plug-in

## Specific Changes proposed
Please list the specific changes involved in this pull request.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
- [ ] Reviewed by Two Core Contributors
