### PR TITLE
three.js version revert back to v129 as 130 breaks renderer.getSize

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@babel/runtime": "^7.14.5",
     "babel-polyfill": "^6.26.0",
     "global": "^4.4.0",
-    "three": "0.137.5",
+    "three": "0.129.0",
     "video.js": "^6 || ^7",
     "webvr-polyfill": "0.10.12",
     "webxr-polyfill": "^2.0.3"

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -754,13 +754,15 @@ void main() {
           document.body.appendChild(this.vrButton);
           this.initImmersiveVR();
           this.initXRPolyfill(displays);
+        } else {
+          this.initVRPolyfill(displays);
         }
         window.navigator.xr.setSession = (session) => {
           this.currentSession = session;
           this.renderer.xr.setSession(this.currentSession);
         };
       });
-
+    } else {
       this.initVRPolyfill(displays);
     }
   }


### PR DESCRIPTION
## Description
three.js version revert back to v129 as 130 breaks renderer.getSize

## Specific Changes proposed
Please list the specific changes involved in this pull request.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
- [ ] Reviewed by Two Core Contributors
